### PR TITLE
Update safenet.c

### DIFF
--- a/safenet.c
+++ b/safenet.c
@@ -287,8 +287,15 @@ PHP_FUNCTION(safenet_decrypt)
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &arg, &arg_len) == FAILURE) {
 		return;
 	}
-
+    
+    if(arg_len!=512)
+    {
+		len = spprintf(&strg, 0, "%s", arg);
+    }
+    else
+    {
 	len = spprintf(&strg, 0, "%s", safenet(INI_STR("safenet.url"), "decrypt", INI_STR("safenet.key"), arg));
+	}
 	RETURN_STRINGL(strg, len, 0);
 }
 


### PR DESCRIPTION
解密前先判断长度是否为512，若不是，则返回原字符
